### PR TITLE
Updated "browsermob-proxy" to "2.1.4"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM java:8-jre-alpine
 MAINTAINER Bruno Wowk "bruno.wowk@gmail.com"
 
-ADD https://github.com/lightbody/browsermob-proxy/releases/download/browsermob-proxy-2.1.2/browsermob-proxy-2.1.2-bin.zip /home/
+ADD https://github.com/lightbody/browsermob-proxy/releases/download/browsermob-proxy-2.1.4/browsermob-proxy-2.1.4-bin.zip /home/
 WORKDIR /home
-RUN unzip browsermob-proxy-2.1.2-bin.zip && rm browsermob-proxy-2.1.2-bin.zip
+RUN unzip browsermob-proxy-2.1.4-bin.zip && rm browsermob-proxy-2.1.4-bin.zip
 EXPOSE 8080-8200
-CMD /home/browsermob-proxy-2.1.2/bin/browsermob-proxy
+CMD /home/browsermob-proxy-2.1.4/bin/browsermob-proxy


### PR DESCRIPTION
This pull request updates [browsermob-proxy](https://github.com/lightbody/browsermob-proxy) to its latest version (`2.1.4`).