### PR TITLE
upgrade to java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM java:8-jre-alpine
+FROM mcr.microsoft.com/java/jre:11-zulu-alpine
 MAINTAINER Bruno Wowk "bruno.wowk@gmail.com"
 
 ADD https://github.com/lightbody/browsermob-proxy/releases/download/browsermob-proxy-2.1.4/browsermob-proxy-2.1.4-bin.zip /home/
 WORKDIR /home
 RUN unzip browsermob-proxy-2.1.4-bin.zip && rm browsermob-proxy-2.1.4-bin.zip
 EXPOSE 8080-8200
+RUN chmod +x /home/browsermob-proxy-2.1.4/bin/browsermob-proxy
 CMD /home/browsermob-proxy-2.1.4/bin/browsermob-proxy


### PR DESCRIPTION
we are using this container when running high volume of tests in parallel 50-100 workers to capture network logs. I have noticed that with java8 I was getting a lot of OutOfMemory exceptions and the proxy server was crashing. It also looks like JVM inside container retains memory and does not release it (even though all proxies have been disposed after test runs, see the attached image)

![image](https://user-images.githubusercontent.com/20699180/100206504-50606e80-2efe-11eb-90da-b48d45c68674.png)
) 

After upgrade to java 11 I don't see OOM although not releasing memory is still there, proxy server is constantly consuming about 2gb of memory even in idle state
![image](https://user-images.githubusercontent.com/20699180/100206748-a6cdad00-2efe-11eb-88a3-2348a674ea9d.png)
